### PR TITLE
Define static async isConfigSupported()

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1138,6 +1138,12 @@ Run these steps:
         {{AudioEncoderConfig}}, and {{VideoEncoderConfig}} each define their
         respective configuration entries and defaults.
 
+    NOTE: Support for a given configuration may change dynamically if the
+        hardware is altered (e.g. external GPU unplugged) or if required
+        hardware resources are exhausted. User agents should describe support on
+        a best-effort basis given the resources that are available at the time
+        of the query.
+
 2. Otherwise, return false.
 
 <dfn>Clone Configuration</dfn> (with |config|) {#clone-config}

--- a/index.src.html
+++ b/index.src.html
@@ -153,7 +153,7 @@ interface AudioDecoder {
   undefined reset();
   undefined close();
 
-  static Promise<boolean> isConfigSupported(AudioDecoderConfig config);
+  static Promise<AudioDecoderSupport> isConfigSupported(AudioDecoderConfig config);
 };
 
 dictionary AudioDecoderInit {
@@ -225,12 +225,12 @@ Methods {#audiodecoder-methods}
 
     <a>Running a control message</a> to configure the decoder means running
     these steps:
-    1. Let |supported| be the result of running the <a>Check Configuration 
-        Support</a> algorith with |config|. 
-    2. If |supported| is `true`, assign 
+    1. Let |supported| be the result of running the <a>Check Configuration
+        Support</a> algorith with |config|.
+    2. If |supported| is `true`, assign
         {{AudioDecoder/[[codec implementation]]}} with an implementation
         supporting |config|.
-    3. Otherwise, run the <a>Close AudioDecoder</a> algorithm with 
+    3. Otherwise, run the <a>Close AudioDecoder</a> algorithm with
         {{NotSupportedError}}.
   </dd>
 
@@ -300,13 +300,30 @@ Methods {#audiodecoder-methods}
 
   <dt><dfn method for=AudioDecoder>isConfigSupported(config)</dfn></dt>
   <dd>
+    Returns a promise indicating whether the provided |config| is supported by
+    the user agent.
+
+    NOTE: The returned {{AudioDecoderSupport}} {{AudioDecoderSupport/config}}
+        will contain only the dictionary members that user agent recognized.
+        Unrecognized dictionary memebers will be ignored. Authors may detect
+        unrecognized dictionary members by comparinging
+        {{AudioDecoderSupport/config}} to their provided |config|.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid AudioDecoderConfig</a>, return
         [=a promise rejected with=] {{TypeError}}.
     2. Let |p| be a new Promise.
-    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
-        with |config| and resolve |p| with its result.
-    4. Return  p.
+    3. Let |checkSupportQueue| be the result of starting a new <a>parallel
+        queue</a>.
+    4. Enqueue the following steps to |checkSupportQueue|:
+        1. Let |decoderSupport| be a newly constructed
+            {{AudioDecoderSupport}}, initialized as follows:
+            1. Set {{AudioDecoderSupport/config}} to the result of running the
+                <a>Clone Configuration</a> algorithm with |config|.
+            2. Set {{AudioDecoderSupport/supported}} to the result of running
+                the <a>Check Configuration Support</a> algorithm with |config|.
+        2. Resolve |p| with |decoderSupport|.
+    5. Return  |p|.
   </dd>
 </dl>
 
@@ -361,7 +378,7 @@ interface VideoDecoder {
   undefined reset();
   undefined close();
 
-  static Promise<boolean> isConfigSupported(VideoDecoderConfig config);
+  static Promise<VideoDecoderSupport> isConfigSupported(VideoDecoderConfig config);
 };
 
 dictionary VideoDecoderInit {
@@ -433,12 +450,12 @@ Methods {#videodecoder-methods}
 
     <a>Running a control message</a> to configure the decoder means running
     these steps:
-    1. Let |supported| be the result of running the <a>Check Configuration 
-        Support</a> algorith with |config|. 
-    2. If |supported| is `true`, assign 
+    1. Let |supported| be the result of running the <a>Check Configuration
+        Support</a> algorith with |config|.
+    2. If |supported| is `true`, assign
         {{VideoDecoder/[[codec implementation]]}} with an implementation
         supporting |config|.
-    3. Otherwise, run the <a>Close VideoDecoder</a> algorithm with 
+    3. Otherwise, run the <a>Close VideoDecoder</a> algorithm with
         {{NotSupportedError}}.
   </dd>
 
@@ -506,16 +523,33 @@ Methods {#videodecoder-methods}
 
     When invoked, run the <a>Close VideoDecoder</a> algorithm.
   </dd>
-  
+
   <dt><dfn method for=VideoDecoder>isConfigSupported(config)</dfn></dt>
   <dd>
+    Returns a promise indicating whether the provided |config| is supported by
+    the user agent.
+
+    NOTE: The returned {{VideoDecoderSupport}} {{VideoDecoderSupport/config}}
+        will contain only the dictionary members that user agent recognized.
+        Unrecognized dictionary memebers will be ignored. Authors may detect
+        unrecognized dictionary members by comparinging
+        {{VideoDecoderSupport/config}} to their provided |config|.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid VideoDecoderConfig</a>, return
         [=a promise rejected with=] {{TypeError}}.
     2. Let |p| be a new Promise.
-    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
-        with |config| and resolve |p| with its result.
-    4. Return  p.
+    3. Let |checkSupportQueue| be the result of starting a new <a>parallel
+        queue</a>.
+    4. Enqueue the following steps to |checkSupportQueue|:
+        1. Let |decoderSupport| be a newly constructed
+            {{VideoDecoderSupport}}, initialized as follows:
+            1. Set {{VideoDecoderSupport/config}} to the result of running the
+                <a>Clone Configuration</a> algorithm with |config|.
+            2. Set {{VideoDecoderSupport/supported}} to the result of running
+                the <a>Check Configuration Support</a> algorithm with |config|.
+        2. Resolve |p| with |decoderSupport|.
+    5. Return  |p|.
   </dd>
 </dl>
 
@@ -587,7 +621,7 @@ interface AudioEncoder {
   undefined reset();
   undefined close();
 
-  static Promise<boolean> isConfigSupported(AudioEncoderConfig config);
+  static Promise<AudioEncoderSupport> isConfigSupported(AudioEncoderConfig config);
 };
 
 dictionary AudioEncoderInit {
@@ -659,12 +693,12 @@ Methods {#audioencoder-methods}
 
     Running a control message to configure the encoder means performing these
     steps:
-    1. Let |supported| be the result of running the <a>Check Configuration 
-        Support</a> algorith with |config|. 
-    2. If |supported| is `true`, assign 
+    1. Let |supported| be the result of running the <a>Check Configuration
+        Support</a> algorith with |config|.
+    2. If |supported| is `true`, assign
         {{AudioEncoder/[[codec implementation]]}} with an implementation
         supporting |config|.
-    3. Otherwise, run the <a>Close AudioEncoder</a> algorithm with 
+    3. Otherwise, run the <a>Close AudioEncoder</a> algorithm with
         {{NotSupportedError}}.
   </dd>
 
@@ -743,13 +777,30 @@ Methods {#audioencoder-methods}
 
   <dt><dfn method for=AudioEncoder>isConfigSupported(config)</dfn></dt>
   <dd>
+    Returns a promise indicating whether the provided |config| is supported by
+    the user agent.
+
+    NOTE: The returned {{AudioEncoderSupport}} {{AudioEncoderSupport/config}}
+        will contain only the dictionary members that user agent recognized.
+        Unrecognized dictionary memebers will be ignored. Authors may detect
+        unrecognized dictionary members by comparinging
+        {{AudioEncoderSupport/config}} to their provided |config|.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid AudioEncoderConfig</a>, return
         [=a promise rejected with=] {{TypeError}}.
     2. Let |p| be a new Promise.
-    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
-        with |config| and resolve |p| with its result.
-    4. Return  p.
+    3. Let |checkSupportQueue| be the result of starting a new <a>parallel
+        queue</a>.
+    4. Enqueue the following steps to |checkSupportQueue|:
+        1. Let |encoderSupport| be a newly constructed
+            {{AudioEncoderSupport}}, initialized as follows:
+            1. Set {{AudioEncoderSupport/config}} to the result of running the
+                <a>Clone Configuration</a> algorithm with |config|.
+            2. Set {{AudioEncoderSupport/supported}} to the result of running
+                the <a>Check Configuration Support</a> algorithm with |config|.
+        2. Resolve |p| with |encoderSupport|.
+    5. Return  |p|.
   </dd>
 </dl>
 
@@ -888,12 +939,12 @@ Methods {#videoencoder-methods}
 
     Running a control message to configure the encoder means performing these
     steps:
-    1. Let |supported| be the result of running the <a>Check Configuration 
-        Support</a> algorith with |config|. 
-    2. If |supported| is `true`, assign 
+    1. Let |supported| be the result of running the <a>Check Configuration
+        Support</a> algorith with |config|.
+    2. If |supported| is `true`, assign
         {{VideoEncoder/[[codec implementation]]}} with an implementation
         supporting |config|.
-    3. Otherwise, run the <a>Close VideoEncoder</a> algorithm with 
+    3. Otherwise, run the <a>Close VideoEncoder</a> algorithm with
         {{NotSupportedError}} and abort these steps.
     2. Set {{VideoEncoder/[[active encoder config]]}} to `config`.
   </dd>
@@ -973,13 +1024,30 @@ Methods {#videoencoder-methods}
 
   <dt><dfn method for=VideoEncoder>isConfigSupported(config)</dfn></dt>
   <dd>
+    Returns a promise indicating whether the provided |config| is supported by
+    the user agent.
+
+    NOTE: The returned {{VideoEncoderSupport}} {{VideoEncoderSupport/config}}
+        will contain only the dictionary members that user agent recognized.
+        Unrecognized dictionary memebers will be ignored. Authors may detect
+        unrecognized dictionary members by comparinging
+        {{VideoEncoderSupport/config}} to their provided |config|.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid VideoEncoderConfig</a>, return
         [=a promise rejected with=] {{TypeError}}.
     2. Let |p| be a new Promise.
-    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
-        with |config| and resolve |p| with its result.
-    4. Return  p.
+    3. Let |checkSupportQueue| be the result of starting a new <a>parallel
+        queue</a>.
+    4. Enqueue the following steps to |checkSupportQueue|:
+        1. Let |encoderSupport| be a newly constructed
+            {{VideoEncoderSupport}}, initialized as follows:
+            1. Set {{VideoEncoderSupport/config}} to the result of running the
+                <a>Clone Configuration</a> algorithm with |config|.
+            2. Set {{VideoEncoderSupport/supported}} to the result of running
+                the <a>Check Configuration Support</a> algorithm with |config|.
+        2. Resolve |p| with |encoderSupport|.
+    5. Return  |p|.
   </dd>
 </dl>
 
@@ -1061,15 +1129,128 @@ Configurations{#configurations}
 
 <dfn>Check Configuration Support</dfn> (with |config|) {#config-support}
 ------------------------------------------------------------------------
+Run these steps:
 1. If the user agent can provide a <a>codec</a> to support all entries of the
-    |config|, including applicable default values for keys that are not 
+    |config|, including applicable default values for keys that are not
     included, return `true`.
 
     NOTE: The types {{AudioDecoderConfig}}, {{VideoDecoderConfig}},
-        {{AudioEncoderConfig}}, and {{VideoEncoderConfig}} each define their 
+        {{AudioEncoderConfig}}, and {{VideoEncoderConfig}} each define their
         respective configuration entries and defaults.
 
 2. Otherwise, return false.
+
+<dfn>Clone Configuration</dfn> (with |config|) {#clone-config}
+--------------------------------------------------------------
+
+NOTE: This algorithm will copy only the dictionary members that the user agent
+    recognizes as part of the dictionary type.
+
+Run these steps:
+1. Let |dictType| be the type of dictionary |config|.
+2. Let <var ignore=''>clone</var> be a new empty instance of |dictType|.
+3. For each dictionary member |m| defined on |dictType|:
+    1. If |m| does not [=map/exist=] in |config|, then [=iteration/continue=].
+    2. If `config[m]` is a nested dictionary, set `clone[m]` to the result of
+        recursively running the <a>Clone Configuration</a> algorithm with
+        `config[m]`.
+    3. Otherwise, assign the value of `config[m]` to `clone[m]`.
+
+
+Signalling Configuration Support{#config-support-info}
+------------------------------------------------------
+
+### AudioDecoderSupport ### {#audio-decoder-support}
+<pre class='idl'>
+<xmp>
+dictionary AudioDecoderSupport {
+  boolean supported;
+  AudioDecoderConfig config;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=AudioDecoderSupport>supported</dfn></dt>
+  <dd>
+    A boolean indicating the whether the corresponding
+    {{AudioDecoderSupport/config}} is supported by the user agent.
+  </dd>
+  <dt><dfn dict-member for=AudioDecoderSupport>config</dfn></dt>
+  <dd>
+    An {{AudioDecoderConfig}} used by the user agent in determining the value of
+    {{AudioDecoderSupport/supported}}.
+  </dd>
+</dl>
+
+### VideoDecoderSupport ### {#video-decoder-support}
+<pre class='idl'>
+<xmp>
+dictionary VideoDecoderSupport {
+  boolean supported;
+  VideoDecoderConfig config;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=VideoDecoderSupport>supported</dfn></dt>
+  <dd>
+    A boolean indicating the whether the corresponding
+    {{VideoDecoderSupport/config}} is supported by the user agent.
+  </dd>
+  <dt><dfn dict-member for=VideoDecoderSupport>config</dfn></dt>
+  <dd>
+    A {{VideoDecoderConfig}} used by the user agent in determining the value of
+    {{VideoDecoderSupport/supported}}.
+  </dd>
+</dl>
+
+### AudioEncoderSupport ### {#audio-encoder-support}
+<pre class='idl'>
+<xmp>
+dictionary AudioEncoderSupport {
+  boolean supported;
+  AudioEncoderConfig config;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=AudioEncoderSupport>supported</dfn></dt>
+  <dd>
+    A boolean indicating the whether the corresponding
+    {{AudioEncoderSupport/config}} is supported by the user agent.
+  </dd>
+  <dt><dfn dict-member for=AudioEncoderSupport>config</dfn></dt>
+  <dd>
+    An {{AudioEncoderConfig}} used by the user agent in determining the value of
+    {{AudioEncoderSupport/supported}}.
+  </dd>
+</dl>
+
+### VideoEncoderSupport ### {#video-encoder-support}
+<pre class='idl'>
+<xmp>
+dictionary VideoEncoderSupport {
+  boolean supported;
+  VideoEncoderConfig config;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=VideoEncoderSupport>supported</dfn></dt>
+  <dd>
+    A boolean indicating the whether the corresponding
+    {{VideoEncoderSupport/config}} is supported by the user agent.
+  </dd>
+  <dt><dfn dict-member for=VideoEncoderSupport>config</dfn></dt>
+  <dd>
+    A {{VideoEncoderConfig}} used by the user agent in determining the value of
+    {{VideoEncoderSupport/supported}}.
+  </dd>
+</dl>
 
 <dfn export>Codec String</dfn>{#config-codec-string}
 ----------------------------------------------------

--- a/index.src.html
+++ b/index.src.html
@@ -62,7 +62,7 @@ spec: infra; urlPrefix: https://infra.spec.whatwg.org/#
 Definitions {#definitions}
 ==========================
 
-: Codec
+: <dfn>Codec</dfn>
 :: Refers generically to an instance of AudioDecoder, AudioEncoder,
     VideoDecoder, or VideoEncoder.
 
@@ -152,6 +152,8 @@ interface AudioDecoder {
   Promise<undefined> flush();
   undefined reset();
   undefined close();
+
+  static Promise<boolean> isConfigSupported(AudioDecoderConfig config);
 };
 
 dictionary AudioDecoderInit {
@@ -209,20 +211,27 @@ Methods {#audiodecoder-methods}
     <a>Enqueues a control message</a> to configure the audio decoder for
     decoding chunks as described by |config|.
 
+    NOTE: Authors should first check support by calling
+        {{AudioDecoder/isConfigSupported()}} with |config| to avoid error paths
+        in the steps below.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid AudioDecoderConfig</a>, throw a
         {{TypeError}}.
     2. If {{AudioDecoder/state}} is `“closed”`, throw an {{InvalidStateError}}.
-    3. If the user agent cannot provide a codec implementation to support
-        |config|, throw a {{NotSupportedError}}.
-    4. Set {{AudioDecoder/state}} to `"configured"`.
-    5. <a>Queue a control message</a> to configure the decoder with |config|.
-    6. <a>Run the control message processing loop</a>.
+    3. Set {{AudioDecoder/state}} to `"configured"`.
+    4. <a>Queue a control message</a> to configure the decoder with |config|.
+    5. <a>Run the control message processing loop</a>.
 
     <a>Running a control message</a> to configure the decoder means running
     these steps:
-    1. Assign {{AudioDecoder/[[codec implementation]]}} with an implementation
+    1. Let |supported| be the result of running the <a>Check Configuration 
+        Support</a> algorith with |config|. 
+    2. If |supported| is `true`, assign 
+        {{AudioDecoder/[[codec implementation]]}} with an implementation
         supporting |config|.
+    3. Otherwise, run the <a>Close AudioDecoder</a> algorithm with 
+        {{NotSupportedError}}.
   </dd>
 
   <dt><dfn method for=AudioDecoder>decode(chunk)</dfn></dt>
@@ -288,6 +297,17 @@ Methods {#audiodecoder-methods}
 
     When invoked, run the <a>Close AudioDecoder</a> algorithm.
   </dd>
+
+  <dt><dfn method for=AudioDecoder>isConfigSupported(config)</dfn></dt>
+  <dd>
+    When invoked, run these steps:
+    1. If |config| is not a <a>valid AudioDecoderConfig</a>, return
+        [=a promise rejected with=] {{TypeError}}.
+    2. Let |p| be a new Promise.
+    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
+        with |config| and resolve |p| with its result.
+    4. Return  p.
+  </dd>
 </dl>
 
 Algorithms {#audiodecoder-algorithms}
@@ -340,6 +360,8 @@ interface VideoDecoder {
   Promise<undefined> flush();
   undefined reset();
   undefined close();
+
+  static Promise<boolean> isConfigSupported(VideoDecoderConfig config);
 };
 
 dictionary VideoDecoderInit {
@@ -397,20 +419,27 @@ Methods {#videodecoder-methods}
     <a>Enqueues a control message</a> to configure the video decoder for
     decoding chunks as described by |config|.
 
+    NOTE: Authors should first check support by calling
+        {{VideoDecoder/isConfigSupported()}} with |config| to avoid error paths
+        in the steps below.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid VideoDecoderConfig</a>, throw a
         {{TypeError}}.
     2. If {{VideoDecoder/state}} is `“closed”`, throw an {{InvalidStateError}}.
-    3. If the user agent cannot provide a codec implementation to support
-        |config|, throw a {{NotSupportedError}}.
-    4. Set {{VideoDecoder/state}} to `"configured"`.
-    5. <a>Queue a control message</a> to configure the decoder with |config|.
-    6. <a>Run the control message processing loop</a>.
+    3. Set {{VideoDecoder/state}} to `"configured"`.
+    4. <a>Queue a control message</a> to configure the decoder with |config|.
+    5. <a>Run the control message processing loop</a>.
 
     <a>Running a control message</a> to configure the decoder means running
     these steps:
-    1. Assign {{VideoDecoder/[[codec implementation]]}} with an implementation
+    1. Let |supported| be the result of running the <a>Check Configuration 
+        Support</a> algorith with |config|. 
+    2. If |supported| is `true`, assign 
+        {{VideoDecoder/[[codec implementation]]}} with an implementation
         supporting |config|.
+    3. Otherwise, run the <a>Close VideoDecoder</a> algorithm with 
+        {{NotSupportedError}}.
   </dd>
 
   <dt><dfn method for=VideoDecoder>decode(chunk)</dfn></dt>
@@ -476,6 +505,17 @@ Methods {#videodecoder-methods}
     permanent.
 
     When invoked, run the <a>Close VideoDecoder</a> algorithm.
+  </dd>
+  
+  <dt><dfn method for=VideoDecoder>isConfigSupported(config)</dfn></dt>
+  <dd>
+    When invoked, run these steps:
+    1. If |config| is not a <a>valid VideoDecoderConfig</a>, return
+        [=a promise rejected with=] {{TypeError}}.
+    2. Let |p| be a new Promise.
+    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
+        with |config| and resolve |p| with its result.
+    4. Return  p.
   </dd>
 </dl>
 
@@ -546,6 +586,8 @@ interface AudioEncoder {
   Promise<undefined> flush();
   undefined reset();
   undefined close();
+
+  static Promise<boolean> isConfigSupported(AudioEncoderConfig config);
 };
 
 dictionary AudioEncoderInit {
@@ -603,20 +645,27 @@ Methods {#audioencoder-methods}
     <a>Enqueues a control message</a> to configure the audio encoder for
     decoding chunks as described by |config|.
 
+    NOTE: Authors should first check support by calling
+        {{AudioEncoder/isConfigSupported()}} with |config| to avoid error paths
+        in the steps below.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid AudioEncoderConfig</a>, throw a
         {{TypeError}}.
     2. If {{AudioEncoder/state}} is `"closed"`, throw an {{InvalidStateError}}.
-    3. If the user agent cannot provide a codec implementation to support
-        |config|, throw a {{NotSupportedError}}.
-    4. Set {{AudioEncoder/state}} to `"configured"`.
-    5. <a>Queue a control message</a> to configure the encoder using |config|.
-    6. <a>Run the control message processing loop</a>.
+    3. Set {{AudioEncoder/state}} to `"configured"`.
+    4. <a>Queue a control message</a> to configure the encoder using |config|.
+    5. <a>Run the control message processing loop</a>.
 
     Running a control message to configure the encoder means performing these
     steps:
-    1. Assign {{AudioEncoder/[[codec implementation]]}} with an implementation
+    1. Let |supported| be the result of running the <a>Check Configuration 
+        Support</a> algorith with |config|. 
+    2. If |supported| is `true`, assign 
+        {{AudioEncoder/[[codec implementation]]}} with an implementation
         supporting |config|.
+    3. Otherwise, run the <a>Close AudioEncoder</a> algorithm with 
+        {{NotSupportedError}}.
   </dd>
 
   <dt><dfn method for=AudioEncoder>encode(frame)</dfn></dt>
@@ -691,6 +740,17 @@ Methods {#audioencoder-methods}
 
     When invoked, run the <a>Close AudioEncoder</a> algorithm.
   </dd>
+
+  <dt><dfn method for=AudioEncoder>isConfigSupported(config)</dfn></dt>
+  <dd>
+    When invoked, run these steps:
+    1. If |config| is not a <a>valid AudioEncoderConfig</a>, return
+        [=a promise rejected with=] {{TypeError}}.
+    2. Let |p| be a new Promise.
+    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
+        with |config| and resolve |p| with its result.
+    4. Return  p.
+  </dd>
 </dl>
 
 Algorithms {#audioencoder-algorithms}
@@ -748,6 +808,8 @@ interface VideoEncoder {
   Promise<undefined> flush();
   undefined reset();
   undefined close();
+
+  static Promise<boolean> isConfigSupported(VideoEncoderConfig config);
 };
 
 dictionary VideoEncoderInit {
@@ -812,20 +874,27 @@ Methods {#videoencoder-methods}
     <a>Enqueues a control message</a> to configure the video encoder for
     decoding chunks as described by |config|.
 
+    NOTE: Authors should first check support by calling
+        {{VideoEncoder/isConfigSupported()}} with |config| to avoid error paths
+        in the steps below.
+
     When invoked, run these steps:
     1. If |config| is not a <a>valid VideoEncoderConfig</a>, throw a
         {{TypeError}}.
     2. If {{VideoEncoder/state}} is `"closed"`, throw an {{InvalidStateError}}.
-    3. If the user agent cannot provide a codec implementation to support
-        |config|, throw a {{NotSupportedError}}.
-    4. Set {{VideoEncoder/state}} to `"configured"`.
-    5. <a>Queue a control message</a> to configure the encoder using |config|.
-    6. <a>Run the control message processing loop</a>.
+    3. Set {{VideoEncoder/state}} to `"configured"`.
+    4. <a>Queue a control message</a> to configure the encoder using |config|.
+    5. <a>Run the control message processing loop</a>.
 
     Running a control message to configure the encoder means performing these
     steps:
-    1. Assign {{VideoEncoder/[[codec implementation]]}} with an implementation
+    1. Let |supported| be the result of running the <a>Check Configuration 
+        Support</a> algorith with |config|. 
+    2. If |supported| is `true`, assign 
+        {{VideoEncoder/[[codec implementation]]}} with an implementation
         supporting |config|.
+    3. Otherwise, run the <a>Close VideoEncoder</a> algorithm with 
+        {{NotSupportedError}} and abort these steps.
     2. Set {{VideoEncoder/[[active encoder config]]}} to `config`.
   </dd>
 
@@ -900,6 +969,17 @@ Methods {#videoencoder-methods}
     permanent.
 
     When invoked, run the <a>Close VideoEncoder</a> algorithm.
+  </dd>
+
+  <dt><dfn method for=VideoEncoder>isConfigSupported(config)</dfn></dt>
+  <dd>
+    When invoked, run these steps:
+    1. If |config| is not a <a>valid VideoEncoderConfig</a>, return
+        [=a promise rejected with=] {{TypeError}}.
+    2. Let |p| be a new Promise.
+    3. [=In parallel=], run the <a>Check Configuration Support</a> algorithm
+        with |config| and resolve |p| with its result.
+    4. Return  p.
   </dd>
 </dl>
 
@@ -978,6 +1058,18 @@ Algorithms {#videoencoder-algorithms}
 
 Configurations{#configurations}
 ===============================
+
+<dfn>Check Configuration Support</dfn> (with |config|) {#config-support}
+------------------------------------------------------------------------
+1. If the user agent can provide a <a>codec</a> to support all entries of the
+    |config|, including applicable default values for keys that are not 
+    included, return `true`.
+
+    NOTE: The types {{AudioDecoderConfig}}, {{VideoDecoderConfig}},
+        {{AudioEncoderConfig}}, and {{VideoEncoderConfig}} each define their 
+        respective configuration entries and defaults.
+
+2. Otherwise, return false.
 
 <dfn export>Codec String</dfn>{#config-codec-string}
 ----------------------------------------------------


### PR DESCRIPTION
Earlier drafts wrongly assumed that support could be determined
synchronously.This remedies that by introducing a new async API
to check support prior to calling configure().
    
Fixes #98. See additional discussion there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/120.html" title="Last updated on Feb 17, 2021, 10:21 PM UTC (6fc501a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/120/aec3834...6fc501a.html" title="Last updated on Feb 17, 2021, 10:21 PM UTC (6fc501a)">Diff</a>