### PR TITLE
Make Security Considerations example less verbose

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1865,16 +1865,8 @@ files/streams and invoking the various API control methods.
 
 For example, you can send any stream to a decoder by first wrapping that stream
 in a media container (e.g. mp4) and setting that as the {{HTMLMediaElement/src}}
-of an {{HTMLMediaElement}}. Similarly, you can send any stream to an encoder by
-using {{MediaRecorder}} to capture a stream of "images" from an
-{{HTMLCanvasElement}}, where the image is actually specially crafted binary
-data.
-
-Having loaded the bytes into the codec, you can use existing media APIs as a
-proxy to invoke different codec controls. For example, you can cause an
-underlying video decoder to be {{VideoDecoder/reset()}} by setting a new value
-for `<video>.currentTime`. Similarly, you can cause an underlying video encoder
-to {{VideoEncoder/flush()}} by stopping the {{MediaRecorder}}.
+of an {{HTMLMediaElement}}. You can then cause the underlying video decoder to
+be {{VideoDecoder/reset()}} by setting a new value for `<video>.currentTime`.
 
 WebCodecs makes such attacks easier by exposing low level control when inputs
 are provided and direct access to invoke the codec control methods. This also


### PR DESCRIPTION
Make Security Considerations example less verbose


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/135.html" title="Last updated on Feb 8, 2021, 3:07 PM UTC (813b10c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/135/06da4b3...813b10c.html" title="Last updated on Feb 8, 2021, 3:07 PM UTC (813b10c)">Diff</a>