### PR TITLE
Expose interfaces to DedicatedWorker, not Worker

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -175,7 +175,7 @@ AudioDecoder Interface {#audiodecoder-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface AudioDecoder {
   constructor(AudioDecoderInit init);
 
@@ -366,7 +366,7 @@ VideoDecoder Interface {#videodecoder-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface VideoDecoder {
   constructor(VideoDecoderInit init);
 
@@ -575,7 +575,7 @@ AudioEncoder Interface {#audioencoder-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface AudioEncoder {
   constructor(AudioEncoderInit init);
 
@@ -781,7 +781,7 @@ VideoEncoder Interface {#videoencoder-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface VideoEncoder {
   constructor(VideoEncoderInit init);
 
@@ -1525,7 +1525,7 @@ EncodedVideoChunk Interface{#encodedvideochunk-interface}
 -----------------------------------------------------------
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface EncodedVideoChunk {
   constructor(EncodedVideoChunkInit init);
   readonly attribute EncodedVideoChunkType type;
@@ -1586,7 +1586,7 @@ AudioFrame Interface {#audioframe-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface AudioFrame {
   constructor(AudioFrameInit init);
   readonly attribute unsigned long long timestamp;
@@ -1651,7 +1651,7 @@ VideoFrame Interface {#videoframe-interface}
 
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,DedicatedWorker)]
 interface VideoFrame {
   constructor(ImageBitmap imageBitmap, VideoFrameInit frameInit);
   constructor(PixelFormat pixelFormat, sequence<(Plane or PlaneInit)> planes,

--- a/index.src.html
+++ b/index.src.html
@@ -1479,6 +1479,7 @@ EncodedAudioChunk Interface {#encodedaudiochunk-interface}
 ------------------------------------------------------------
 <pre class='idl'>
 <xmp>
+[Exposed=(Window,DedicatedWorker)]
 interface EncodedAudioChunk {
   constructor(EncodedAudioChunkInit init);
   readonly attribute EncodedAudioChunkType type;


### PR DESCRIPTION
We haven't thought through the implications of exposing to SharedWorker
and ServiceWorker yet. Mentioned briefly in #121. Also #43.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/139.html" title="Last updated on Feb 11, 2021, 3:52 AM UTC (b59de85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/139/2d2f06b...b59de85.html" title="Last updated on Feb 11, 2021, 3:52 AM UTC (b59de85)">Diff</a>