### PR TITLE
Use DOMHighResTimeStamp for all timestamps/durations

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1482,13 +1482,13 @@ EncodedAudioChunk Interface {#encodedaudiochunk-interface}
 interface EncodedAudioChunk {
   constructor(EncodedAudioChunkInit init);
   readonly attribute EncodedAudioChunkType type;
-  readonly attribute unsigned long long timestamp;  // microseconds
+  readonly attribute DOMHighResTimeStamp timestamp;
   readonly attribute ArrayBuffer data;
 };
 
 dictionary EncodedAudioChunkInit {
   required EncodedAudioChunkType type;
-  required unsigned long long timestamp;
+  required DOMHighResTimeStamp timestamp;
   required BufferSource data;
 };
 
@@ -1515,7 +1515,7 @@ enum EncodedAudioChunkType {
   <dd>Describes whether the chunk is a key frame.</dd>
 
   <dt><dfn attribute for=EncodedAudioChunk>timestamp</dfn></dt>
-  <dd>The presentation timestamp, given in microseconds.</dd>
+  <dd>The presentation timestamp, given in floating-point milliseconds.</dd>
 
   <dt><dfn attribute for=EncodedAudioChunk>data</dfn></dt>
   <dd>A sequence of bytes containing encoded audio data.</dd>
@@ -1529,15 +1529,15 @@ EncodedVideoChunk Interface{#encodedvideochunk-interface}
 interface EncodedVideoChunk {
   constructor(EncodedVideoChunkInit init);
   readonly attribute EncodedVideoChunkType type;
-  readonly attribute unsigned long long timestamp;  // microseconds
-  readonly attribute unsigned long long? duration;  // microseconds
+  readonly attribute DOMHighResTimeStamp timestamp;
+  readonly attribute DOMHighResTimeStamp? duration;
   readonly attribute ArrayBuffer data;
 };
 
 dictionary EncodedVideoChunkInit {
   required EncodedVideoChunkType type;
-  required unsigned long long timestamp;
-  unsigned long long duration;
+  required DOMHighResTimeStamp timestamp;
+  DOMHighResTimeStamp duration;
   required BufferSource data;
 };
 
@@ -1566,10 +1566,10 @@ enum EncodedVideoChunkType {
   <dd>Describes whether the chunk is a key frame or not.</dd>
 
   <dt><dfn attribute for=EncodedVideoChunk>timestamp</dfn></dt>
-  <dd>The presentation timestamp, given in microseconds.</dd>
+  <dd>The presentation timestamp, given in floating-point milliseconds.</dd>
 
   <dt><dfn attribute for=EncodedVideoChunk>duration</dfn></dt>
-  <dd>The presentation duration, given in microseconds.</dd>
+  <dd>The presentation duration, given in floating-point milliseconds.</dd>
 
   <dt><dfn attribute for=EncodedVideoChunk>data</dfn></dt>
   <dd>A sequence of bytes containing encoded video data.</dd>
@@ -1589,13 +1589,13 @@ AudioFrame Interface {#audioframe-interface}
 [Exposed=(Window,Worker)]
 interface AudioFrame {
   constructor(AudioFrameInit init);
-  readonly attribute unsigned long long timestamp;
+  readonly attribute DOMHighResTimeStamp timestamp;
   readonly attribute AudioBuffer? buffer;
   undefined close();
 };
 
 dictionary AudioFrameInit {
-  required unsigned long long timestamp;
+  required DOMHighResTimeStamp timestamp;
   required AudioBuffer buffer;
 };
 </xmp>
@@ -1625,7 +1625,7 @@ dictionary AudioFrameInit {
 ### Attributes ###{#audioframe-attributes}
 <dl>
   <dt><dfn attribute for=AudioFrame>timestamp</dfn></dt>
-  <dd>The presentation timestamp, given in microseconds.</dd>
+  <dd>The presentation timestamp, given in floating-point milliseconds.</dd>
 
   <dt><dfn attribute for=AudioFrame>buffer</dfn></dt>
   <dd>The buffer containing decoded audio data.</dd>
@@ -1667,8 +1667,8 @@ interface VideoFrame {
   readonly attribute unsigned long cropHeight;
   readonly attribute unsigned long displayWidth;
   readonly attribute unsigned long displayHeight;
-  readonly attribute unsigned long long? duration;
-  readonly attribute unsigned long long? timestamp;
+  readonly attribute DOMHighResTimeStamp? duration;
+  readonly attribute DOMHighResTimeStamp? timestamp;
 
   undefined destroy();
   VideoFrame clone();
@@ -1687,8 +1687,8 @@ dictionary VideoFrameInit {
   unsigned long cropHeight;
   unsigned long displayWidth;
   unsigned long displayHeight;
-  unsigned long long duration;
-  unsigned long long timestamp;
+  DOMHighResTimeStamp duration;
+  DOMHighResTimeStamp timestamp;
 };
 </xmp>
 </pre>
@@ -1804,12 +1804,12 @@ NOTE: this section needs work. Current wording assumes a VideoFrame can always
 <dl>
   <dt><dfn attribute for=VideoFrame>timestamp</dfn></dt>
   <dd>
-    The presentation timestamp, given in microseconds. The timestamp is copied
+    The presentation timestamp, given in floating-point milliseconds. The timestamp is copied
         from the EncodedVideoChunk corresponding to this VideoFrame.
   </dd>
   <dt><dfn attribute for=VideoFrame>duration</dfn></dt>
   <dd>
-    The presentation duration, given in microseconds. The duration is copied
+    The presentation duration, given in floating-point milliseconds. The duration is copied
         from the EncodedVideoChunk corresponding to this VideoFrame.
   </dd>
   <dt><dfn attribute for=VideoFrame>format</dfn></dt>


### PR DESCRIPTION
Fixes #122


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/140.html" title="Last updated on Feb 11, 2021, 4:48 AM UTC (e303378)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/140/9baf37c...e303378.html" title="Last updated on Feb 11, 2021, 4:48 AM UTC (e303378)">Diff</a>