### PR TITLE
Make VideoFrameInit arguments optional

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1654,9 +1654,9 @@ VideoFrame Interface {#videoframe-interface}
 <xmp>
 [Exposed=(Window,DedicatedWorker)]
 interface VideoFrame {
-  constructor(ImageBitmap imageBitmap, VideoFrameInit frameInit);
+  constructor(ImageBitmap imageBitmap, optional VideoFrameInit frameInit = {});
   constructor(PixelFormat pixelFormat, sequence<(Plane or PlaneInit)> planes,
-              VideoFrameInit frameInit);
+              optional VideoFrameInit frameInit = {});
 
   readonly attribute PixelFormat format;
   readonly attribute FrozenArray<Plane> planes;


### PR DESCRIPTION
This is required by Web IDL since VideoFrameInit has no required members.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/web-codecs/pull/142.html" title="Last updated on Feb 17, 2021, 1:26 PM UTC (c52a5c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/142/4905c4f...foolip:c52a5c7.html" title="Last updated on Feb 17, 2021, 1:26 PM UTC (c52a5c7)">Diff</a>