### PR TITLE
Establish codec registry and AVC registration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-out/
-index.html
+avc_codec_registration.html
+codec_registry.html
 deploy_key
 deploy_key.pub
+index.html
+out/
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 SHELL=/bin/bash
 
-local: index.src.html
+local: local-index local-codec-registry local-avc-codec-registration
+
+local-index: index.src.html
 	bikeshed --die-on=warning spec index.src.html index.html
 
-index.html: index.src.html
+local-codec-registry: codec_registry.src.html
+	bikeshed --die-on=warning spec codec_registry.src.html codec_registry.html
+
+local-avc-codec-registration: avc_codec_registration.src.html
+	bikeshed --die-on=warning spec avc_codec_registration.src.html avc_codec_registration.html
+
+remote-index: index.src.html
 	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
 	                       --output index.html \
 	                       --write-out "%{http_code}" \
@@ -16,14 +24,38 @@ index.html: index.src.html
 		exit 22 \
 	);
 
-remote: index.html
+remote-codec-registry: codec_registry.src.html
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output codec_registry.html \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+	                       -F die-on=warning \
+	                       -F file=@codec_registry.src.html) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat codec_registry.html; echo ""; \
+		rm -f codec_registry.html; \
+		exit 22 \
+	);
 
-ci: index.src.html
+remote-avc-codec-registration: avc_codec_registration.src.html
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output avc_codec_registration.html \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+	                       -F die-on=warning \
+	                       -F file=@avc_codec_registration.src.html) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat avc_codec_registration.html; echo ""; \
+		rm -f avc_codec_registration.html; \
+		exit 22 \
+	);
+
+
+remote: remote-index remote-codec-registry remote-avc-codec-registration
+
+ci: index.src.html codec_registry.src.html avc_codec_registration.src.html
 	mkdir -p out
 	make remote
 	mv index.html out/index.html
-
-clean:
-	rm index.html
-	rm -rf out
-
+	mv codec_registry.html out/codec_registry.html
+	mv avc_codec_registration.html out/avc_codec_registration.html

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -11,10 +11,10 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 Boilerplate: omit conformance
 
-Abstract: This registration is entered into the [[WebCodecs-Codec-Registry]]. It
-    describes, for AVC (H.264), the (1) fully qualified codec strings, (2) the
-    {{WebCodecs/VideoDecoderConfig.description}} bytes, and (3) the
-    codec-sepcific extensions to the {{WebCodecs/VideoEncoderConfig}}.
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for AVC (H.264), the (1) fully qualified codec strings, (2)
+    the {{VideoDecoderConfig.description}} bytes, and (3) the
+    codec-specific extensions to the {{VideoEncoderConfig}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -31,20 +31,25 @@ Markup Shorthands:css no, markdown yes, dfn yes
 </pre>
 
 <pre class='anchors'>
-spec: web-codecs; for: WebCodecs; urlPrefix: https://wicg.github.io/web-codecs/#
+spec: webcodecs; urlPrefix: https://wicg.github.io/web-codecs/#
     type: attribute
         text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
     type: interface
         text: EncodedVideoChunk; url: encodedvideochunk
         text: VideoEncoder; url: videoencoder
     type: dictionary
-        text: VideoEncoderConfig; url: video-encoder-config
+        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
         text: VideoDecoderConfig; url: dictdef-videodecoderconfig
 </pre>
 
 <pre class='biblio'>
 {
-  "WebCodecs-Codec-Registry": {
+  "webcodecs": {
+      "href": "https://wicg.github.io/web-codecs/",
+      "title": "WebCodecs",
+      "publisher": "WICG"
+  },
+  "webcodecs-codec-registry": {
       "href": "https://wicg.github.io/web-codecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
       "publisher": "WICG"
@@ -72,17 +77,17 @@ NOTE: The common "avc3." prefix is intentionally not included. This prefix does
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-A {{WebCodecs/VideoDecoderConfig.description}} may or may not be required by the
+A {{VideoDecoderConfig.description}} may or may not be required by the
 AVC codec depending on the bitstream format of the AVC content to be decoded.
 
-If the {{WebCodecs/VideoDecoderConfig.description}} includes an
+If the {{VideoDecoderConfig.description}} includes an
 `AVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section 5.3.3.1,
 it will be assumed that the bitstream is in "avc" format.
 
 NOTE: This format is commonly used in .MP4 files, where the player generally has
     random access to the media data.
 
-If the {{WebCodecs/VideoDecoderConfig.description}} is not provided, it will be
+If the {{VideoDecoderConfig.description}} is not provided, it will be
 assumed that the bitstream is in “annexb” format.
 
 NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.264]],
@@ -95,7 +100,7 @@ VideoEncoderConfig extensions {#videoencoderconfig-extensions}
 
 <pre class='idl'>
 <xmp>
-/* partial */ dictionary VideoEncoderConfig {
+partial dictionary VideoEncoderConfig {
   AvcEncoderConfig avc;
 };
 </xmp>
@@ -121,7 +126,7 @@ dictionary AvcEncoderConfig {
 <dl>
   <dt><dfn dict-member for=AvcEncoderConfig>format</dfn></dt>
   <dd>
-    Configures the format of output {{WebCodecs/EncodedVideoChunk}}s. See
+    Configures the format of output {{EncodedVideoChunk}}s. See
     {{AvcBitstreamFormat}}.
   </dd>
 </dl>
@@ -157,9 +162,9 @@ SPS and PPS are described in greater detail in sections G.3.41 and G.3.55 of
   <dt><dfn enum-value for=AvcBitstreamFormat>avc</dfn></dt>
   <dd>
     SPS and PPS data are not included in the bitstream and are instead emitted
-    via the {{WebCodecs/VideoEncoder}} [[output callback]] as the
-    {{WebCodecs/VideoDecoderConfig.description}} of the
-    {{WebCodecs/VideoDecoderConfig}}.
+    via the {{VideoEncoder}} [[output callback]] as the
+    {{VideoDecoderConfig.description}} of the
+    {{VideoDecoderConfig}}.
     <var ignore=''>output_config</var>.
 
     NOTE: This format is described in greater detail by [[iso14496-15]],

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -2,7 +2,7 @@
 Title: AVC (H.264) WebCodecs Registration
 Repository: wicg/web-codecs
 Status: CG-DRAFT
-Shortname: web-codecs-avc-codec-registration
+Shortname: webcodecs-avc-codec-registration
 Level: none
 Group: wicg
 ED: none
@@ -44,12 +44,12 @@ spec: webcodecs; urlPrefix: https://wicg.github.io/web-codecs/#
 
 <pre class='biblio'>
 {
-  "webcodecs": {
+  "WEBCODECS": {
       "href": "https://wicg.github.io/web-codecs/",
       "title": "WebCodecs",
       "publisher": "WICG"
   },
-  "webcodecs-codec-registry": {
+  "WEBCODECS-CODEC-REGISTRY": {
       "href": "https://wicg.github.io/web-codecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
       "publisher": "WICG"
@@ -81,11 +81,11 @@ A {{VideoDecoderConfig.description}} may or may not be required by the
 AVC codec depending on the bitstream format of the AVC content to be decoded.
 
 If the {{VideoDecoderConfig.description}} includes an
-`AVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section 5.3.3.1,
-it will be assumed that the bitstream is in "avc" format.
+`AVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section
+5.3.3.1, it will be assumed that the bitstream is in "avc" format.
 
-NOTE: This format is commonly used in .MP4 files, where the player generally has
-    random access to the media data.
+NOTE: This format is commonly used in .MP4 files, where the player generally
+    has random access to the media data.
 
 If the {{VideoDecoderConfig.description}} is not provided, it will be
 assumed that the bitstream is in “annexb” format.

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -1,0 +1,168 @@
+<pre class='metadata'>
+Title: AVC (H.264) WebCodecs Registration
+Repository: wicg/web-codecs
+Status: CG-DRAFT
+Shortname: web-codecs-avc-codec-registration
+Level: none
+Group: wicg
+ED: none
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Boilerplate: omit conformance
+
+Abstract: This registration is entered into the [[WebCodecs-Codec-Registry]]. It
+    describes, for AVC (H.264), the (1) fully qualified codec strings, (2) the
+    {{WebCodecs/VideoDecoderConfig.description}} bytes, and (3) the
+    codec-sepcific extensions to the {{WebCodecs/VideoEncoderConfig}}.
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the AVC / H.264 codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
+!Participate: <a href="https://github.com/wicg/web-codecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/wicg/web-codecs/commits">https://github.com/wicg/web-codecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: web-codecs; for: WebCodecs; urlPrefix: https://wicg.github.io/web-codecs/#
+    type: attribute
+        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
+    type: interface
+        text: EncodedVideoChunk; url: encodedvideochunk
+        text: VideoEncoder; url: videoencoder
+    type: dictionary
+        text: VideoEncoderConfig; url: video-encoder-config
+        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "WebCodecs-Codec-Registry": {
+      "href": "https://wicg.github.io/web-codecs/codec_registry.html",
+      "title": "WebCodecs Codec Registry",
+      "publisher": "WICG"
+  },
+  "ITU-T-REC-H.264": {
+    "href": "https://www.itu.int/rec/T-REC-H.264",
+    "title": "H.264 : Advanced video coding for generic audiovisual services",
+    "publisher": "ITU",
+    "date": "June 2019"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string must begin with the prefix "avc1.", and contain a suffix of 6
+characters as described in Section 3.4 of [[rfc6381]].
+
+NOTE: The common "avc3." prefix is intentionally not included. This prefix does
+  not signal a material difference to decoder inputs, so it is omitted for
+  simplification. For the purposes of this registration, authors should simply
+  map "avc3." to "avc1.".
+
+VideoDecoderConfig description {#videodecoderconfig-description}
+================================================================
+
+A {{WebCodecs/VideoDecoderConfig.description}} may or may not be required by the
+AVC codec depending on the bitstream format of the AVC content to be decoded.
+
+If the {{WebCodecs/VideoDecoderConfig.description}} includes an
+`AVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section 5.3.3.1,
+it will be assumed that the bitstream is in "avc" format.
+
+NOTE: This format is commonly used in .MP4 files, where the player generally has
+    random access to the media data.
+
+If the {{WebCodecs/VideoDecoderConfig.description}} is not provided, it will be
+assumed that the bitstream is in “annexb” format.
+
+NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.264]],
+    Annex B. This format is commonly used in live-streaming applications, where
+    including the SPS and PPS data periodically allows users to easily start
+    from the middle of the stream.
+
+VideoEncoderConfig extensions {#videoencoderconfig-extensions}
+==============================================================
+
+<pre class='idl'>
+<xmp>
+/* partial */ dictionary VideoEncoderConfig {
+  AvcEncoderConfig avc;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=VideoEncoderConfig>avc</dfn></dt>
+  <dd>
+    Contains codec specific configuration options for the AVC (H.264) codec.
+  </dd>
+</dl>
+
+AvcEncoderConfig {#avc-encoder-config}
+--------------------------------------
+<pre class='idl'>
+<xmp>
+dictionary AvcEncoderConfig {
+  AvcBitstreamFormat format = "avc";
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=AvcEncoderConfig>format</dfn></dt>
+  <dd>
+    Configures the format of output {{WebCodecs/EncodedVideoChunk}}s. See
+    {{AvcBitstreamFormat}}.
+  </dd>
+</dl>
+
+AvcBitstreamFormat {#avc-bitstream-format}
+------------------------------------------
+<pre class='idl'>
+<xmp>
+enum AvcBitstreamFormat {
+  "annexb",
+  "avc",
+};
+</xmp>
+</pre>
+
+The {{AvcBitstreamFormat}} determines the location of AVC Sequence Parameter
+Set (SPS) and Picture Parameter Set (PPS) data, and mechanisms for packaging
+the bitstream.
+
+SPS and PPS are described in greater detail in sections G.3.41 and G.3.55 of
+[[ITU-T-REC-H.264]].
+
+<dl>
+  <dt><dfn enum-value for=AvcBitstreamFormat>annexb</dfn></dt>
+  <dd>
+    SPS and PPS data are included periodically throughout the bitstream.
+
+    NOTE: This format is described in greater detail by [[ITU-T-REC-H.264]],
+        Annex B. This format is commonly used in live-streaming applications,
+        where including the SPS and PPS data periodically allows users to easily
+        start from the middle of the stream.
+  </dd>
+  <dt><dfn enum-value for=AvcBitstreamFormat>avc</dfn></dt>
+  <dd>
+    SPS and PPS data are not included in the bitstream and are instead emitted
+    via the {{WebCodecs/VideoEncoder}} [[output callback]] as the
+    {{WebCodecs/VideoDecoderConfig.description}} of the
+    {{WebCodecs/VideoDecoderConfig}}.
+    <var ignore=''>output_config</var>.
+
+    NOTE: This format is described in greater detail by [[iso14496-15]],
+        section 5.3.3.1. This format is commonly used in .MP4 files, where the
+        player generally has random access to the media data.
+</dl>

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -13,10 +13,10 @@ Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.
 Boilerplate: omit conformance
 
 Abstract: This registry is intended to enhance interoperability among
-    implementations and users of [[WebCodecs]]. In particular, this
+    implementations and users of [[webcodecs]]. In particular, this
     registry provides the means to identify and avoid collisions among codec
     strings and provides a mechanism to define codec-specific members of
-    [[WebCodecs]] codec configuration dictionaries.
+    [[webcodecs]] codec configuration dictionaries.
 
     This registry is not intended to include any information on whether a codec
     format is encumbered by intellectual property claims. Implementers and
@@ -34,7 +34,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 </pre>
 
 <pre class='anchors'>
-spec: web-codecs; for: WebCodecs; urlPrefix: https://wicg.github.io/web-codecs/#
+spec: web-codecs; urlPrefix: https://wicg.github.io/web-codecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
@@ -44,12 +44,12 @@ spec: web-codecs; for: WebCodecs; urlPrefix: https://wicg.github.io/web-codecs/#
 
 <pre class='biblio'>
 {
-  "WebCodecs": {
+  "webcodecs": {
       "href": "https://wicg.github.io/web-codecs/",
       "title": "WebCodecs",
       "publisher": "WICG"
   },
-  "AVC-REGISTRATION": {
+  "webcodecs-avc-registration": {
       "href": "https://wicg.github.io/web-codecs/avc_codec_registration.html",
       "title": "AVC (H.264) WebCodecs Registration",
       "publisher": "WICG"
@@ -62,9 +62,9 @@ Organization {#organization}
 
 This registry maintains a mapping between codec strings and definitions for (1)
 fully qualified codec string values, (2) codec-specific values for
-{{WebCodecs/VideoDecoderConfig.description}} and
-{{WebCodecs/AudioDecoderConfig.description}}, and (3) codec-specific members of
-the {{WebCodecs/VideoEncoderConfig}} and {{WebCodecs/AudioEncoderConfig}}
+{{VideoDecoderConfig.description}} and
+{{AudioDecoderConfig.description}}, and (3) codec-specific members of
+the {{VideoEncoderConfig}} and {{AudioEncoderConfig}}
 dictionaries.
 
 Registration Entry Requirements {#registration-entry-requirements}
@@ -76,10 +76,10 @@ Registration Entry Requirements {#registration-entry-requirements}
     a public specification describing how to fully qualify the variable portion
     of the string.
 3. If the described codec requires that codec-specific bytes be provided as part
-    of the {{WebCodecs/VideoDecoderConfig.description}} or the
-    {{WebCodecs/AudioDecoderConfig.description}}, the registration must link to
+    of the {{VideoDecoderConfig.description}} or the
+    {{AudioDecoderConfig.description}}, the registration must link to
     a public specification describing how to populate these fields.
-4. If the {{WebCodecs/AudioEncoderConfig}} or {{WebCodecs/VideoEncoderConfig}}
+4. If the {{AudioEncoderConfig}} or {{VideoEncoderConfig}}
     dictionaries are extended with members specific to the described codec, the
     registration must link to a public specification describing how to populate
     these fields.
@@ -157,7 +157,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>avc1.*</td>
     <td>AVC / H.264</td>
-    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[AVC-REGISTRATION]]</td>
+    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[webcodecs-avc-registration]]</td>
   </tr>
   <tr>
     <td>vp8</td>

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -1,0 +1,172 @@
+<pre class='metadata'>
+Title: WebCodecs Codec Registry
+Repository: wicg/web-codecs
+Status: CG-DRAFT
+Shortname: web-codecs-codec-registry
+Level: none
+Group: wicg
+ED: none
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Boilerplate: omit conformance
+
+Abstract: This registry is intended to enhance interoperability among
+    implementations and users of [[WebCodecs]]. In particular, this
+    registry provides the means to identify and avoid collisions among codec
+    strings and provides a mechanism to define codec-specific members of
+    [[WebCodecs]] codec configuration dictionaries.
+
+    This registry is not intended to include any information on whether a codec
+    format is encumbered by intellectual property claims. Implementers and
+    users are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support any particular codec nor registry
+    entry.
+
+    This registry is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
+!Participate: <a href="https://github.com/wicg/web-codecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/wicg/web-codecs/commits">https://github.com/wicg/web-codecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: web-codecs; for: WebCodecs; urlPrefix: https://wicg.github.io/web-codecs/#
+    type: attribute
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
+        text: VideoEncoderConfig; url: video-encoder-config
+        text: AudioEncoderConfig; url: audio-encoder-config
+</pre>
+
+<pre class='biblio'>
+{
+  "WebCodecs": {
+      "href": "https://wicg.github.io/web-codecs/",
+      "title": "WebCodecs",
+      "publisher": "WICG"
+  },
+  "AVC-REGISTRATION": {
+      "href": "https://wicg.github.io/web-codecs/avc_codec_registration.html",
+      "title": "AVC (H.264) WebCodecs Registration",
+      "publisher": "WICG"
+  }
+}
+</pre>
+
+Organization {#organization}
+============================
+
+This registry maintains a mapping between codec strings and definitions for (1)
+fully qualified codec string values, (2) codec-specific values for
+{{WebCodecs/VideoDecoderConfig.description}} and
+{{WebCodecs/AudioDecoderConfig.description}}, and (3) codec-specific members of
+the {{WebCodecs/VideoEncoderConfig}} and {{WebCodecs/AudioEncoderConfig}}
+dictionaries.
+
+Registration Entry Requirements {#registration-entry-requirements}
+==================================================================
+
+1. Each entry must include a unique codec string and a common name string.
+2. If the codec string contains a fixed prefix with variable suffix values, the
+    suffix must be represented by an asterisk and the registration must link to
+    a public specification describing how to fully qualify the variable portion
+    of the string.
+3. If the described codec requires that codec-specific bytes be provided as part
+    of the {{WebCodecs/VideoDecoderConfig.description}} or the
+    {{WebCodecs/AudioDecoderConfig.description}}, the registration must link to
+    a public specification describing how to populate these fields.
+4. If the {{WebCodecs/AudioEncoderConfig}} or {{WebCodecs/VideoEncoderConfig}}
+    dictionaries are extended with members specific to the described codec, the
+    registration must link to a public specification describing how to populate
+    these fields.
+4. Candidate entries must be announced by filing an issue in the
+    [WebCodecs GitHub issue tracker](https://github.com/wicg/web-codecs/issues/)
+    so they can be discussed and evaluated for compliance before being added to
+    the registry.
+
+Audio Codec Registry {#audio-codec-registry}
+============================================
+
+ISSUE: Several registrations contain TODOs which should be replaced with links
+    to public specifications covering the mentioned definitions.
+
+<table class='data'>
+  <tr>
+    <td>**codec string**</td>
+    <td>**common name**</td>
+    <td>**public specification**</td>
+  </tr>
+  <tr>
+    <td>flac</td>
+    <td>Flac</td>
+    <td>TODO (AudioDecoderConfig.description)</td>
+  </tr>
+  <tr>
+    <td>mp3</td>
+    <td>MP3</td>
+    <td>N/A</td>
+  </tr>
+  <tr>
+    <td>mp4a.*</td>
+    <td>AAC</td>
+    <td>TODO (string + AudioDecoderConfig.description)</td>
+  </tr>
+  <tr>
+    <td>opus</td>
+    <td>Opus</td>
+    <td>TODO (AudioDecoderConfig.description)</td>
+  </tr>
+  <tr>
+    <td>vorbis</td>
+    <td>Vorbis</td>
+    <td>TODO (AudoDecoderConfig.description)</td>
+  </tr>
+  <tr>
+    <td>ulaw</td>
+    <td>PCM u-law</td>
+    <td>N/A</td>
+  </tr>
+  <tr>
+    <td>alaw</td>
+    <td>PCM a-law</td>
+    <td>N/A</td>
+  </tr>
+</table>
+
+Video Codec Registry {#video-codec-registry}
+============================================
+
+ISSUE: Several registrations contain TODOs which should be replaced with links
+    to public specifications covering the mentioned definitions.
+
+<table class='data'>
+  <tr>
+    <td>**codec string**</td>
+    <td>**common name**</td>
+    <td>**specification**</td>
+  </tr>
+  <tr>
+    <td>av01.*</td>
+    <td>AV1</td>
+    <td>TODO (string + VideoDecoderConfig.description)</td>
+  </tr>
+  <tr>
+    <td>avc1.*</td>
+    <td>AVC / H.264</td>
+    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[AVC-REGISTRATION]]</td>
+  </tr>
+  <tr>
+    <td>vp8</td>
+    <td>VP8</td>
+    <td>N/A</td>
+  </tr>
+  <tr>
+    <td>vp09.*</td>
+    <td>VP9</td>
+    <td>TODO (string)</td>
+  </tr>
+</table>

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -2,7 +2,7 @@
 Title: WebCodecs Codec Registry
 Repository: wicg/web-codecs
 Status: CG-DRAFT
-Shortname: web-codecs-codec-registry
+Shortname: webcodecs-codec-registry
 Level: none
 Group: wicg
 ED: none
@@ -44,12 +44,12 @@ spec: web-codecs; urlPrefix: https://wicg.github.io/web-codecs/#
 
 <pre class='biblio'>
 {
-  "webcodecs": {
+  "WEBCODECS": {
       "href": "https://wicg.github.io/web-codecs/",
       "title": "WebCodecs",
       "publisher": "WICG"
   },
-  "webcodecs-avc-registration": {
+  "WEBCODECS-AVC-REGISTRATION": {
       "href": "https://wicg.github.io/web-codecs/avc_codec_registration.html",
       "title": "AVC (H.264) WebCodecs Registration",
       "publisher": "WICG"
@@ -157,7 +157,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>avc1.*</td>
     <td>AVC / H.264</td>
-    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[webcodecs-avc-registration]]</td>
+    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[WEBCODECS-AVC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>vp8</td>

--- a/index.src.html
+++ b/index.src.html
@@ -3,7 +3,7 @@ Title: WebCodecs
 Repository: wicg/web-codecs
 Status: CG-DRAFT
 ED: https://wicg.github.io/web-codecs/
-Shortname: web-codecs
+Shortname: webcodecs
 Level: 1
 Group: wicg
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/

--- a/index.src.html
+++ b/index.src.html
@@ -72,7 +72,7 @@ spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
 
 <pre class='biblio'>
 {
-  "CODEC-REGISTRY": {
+  "WEBCODECS-CODEC-REGISTRY": {
       "href": "https://wicg.github.io/web-codecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
       "publisher": "WICG"
@@ -1140,7 +1140,7 @@ Algorithms {#videoencoder-algorithms}
                     {{VideoDecoderConfig/description}} to describe codec
                     specific "extradata", the use of which may be further
                     described in codec registrations listed in the
-                    [[CODEC-REGISTRY]].
+                    [[WEBCODECS-CODEC-REGISTRY]].
         3. If |output_config| and {{VideoEncoder/[[active output config]]}} are
             <a>equal dictionaries</a>, set |output_config| to null. Otherwise,
             set {{VideoEncoder/[[active output config]]}} to |output_config|.
@@ -1342,7 +1342,7 @@ NOTE: In other media specifications, codec strings historically accompanied a
     hence, only the value of the codecs parameter is accepted.
 
 The format and semantics for codec strings are defined by codec registrations
-listed in the [[CODEC-REGISTRY]]. A compliant implementation may support any
+listed in the [[WEBCODECS-CODEC-REGISTRY]]. A compliant implementation may support any
 combination of codec registrations or none at all.
 
 AudioDecoderConfig{#audio-decoder-config}
@@ -1377,7 +1377,7 @@ To check if an {{AudioDecoderConfig}} is a <dfn>valid AudioDecoderConfig</dfn>,
   <dd>
     A sequence of codec specific bytes, commonly known as extradata.
 
-    NOTE: The registrations in the [[CODEC-REGISTRY]] describe whether/how to
+    NOTE: The registrations in the [[WEBCODECS-CODEC-REGISTRY]] describe whether/how to
         populate this sequence, corresponding to the provided
         {{AudioDecoderConfig/codec}}.
   </dd>
@@ -1428,7 +1428,7 @@ run these steps:
   <dd>
     A sequence of codec specific bytes, commonly known as extradata.
 
-    NOTE: The registrations in the [[CODEC-REGISTRY]] may describe whether/how
+    NOTE: The registrations in the [[WEBCODECS-CODEC-REGISTRY]] may describe whether/how
         to populate this sequence, corresponding to the provided
         {{VideoDecoderConfig/codec}}.
   </dd>
@@ -1502,7 +1502,7 @@ dictionary AudioEncoderConfig {
 </pre>
 
 NOTE: Codec-specific extensions to {{AudioEncoderConfig}} may be defined by the
-    registrations in the [[CODEC-REGISTRY]].
+    registrations in the [[WEBCODECS-CODEC-REGISTRY]].
 
 To check if an {{AudioEncoderConfig}} is a <dfn>valid AudioEncoderConfig</dfn>,
 run these steps:
@@ -1539,7 +1539,7 @@ dictionary VideoEncoderConfig {
 </pre>
 
 NOTE: Codec-specific extensions to {{VideoEncoderConfig}} may be defined by the
-    registrations in the [[CODEC-REGISTRY]].
+    registrations in the [[WEBCODECS-CODEC-REGISTRY]].
 
 To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
     run these steps:

--- a/index.src.html
+++ b/index.src.html
@@ -10,9 +10,14 @@ Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
-Abstract: This specification defines interfaces for encoding and decoding audio
-Abstract: and video. It also includes an interface for retrieving raw video
-Abstract: frames from MediaStreamStracks.
+Abstract: This specification defines interfaces to codecs for encoding and
+    decoding of audio and video.
+
+    This specification does not specify or require any particular codec or
+    method of encoding or decoding. The purpose of this specification is to
+    provide JavaScript interfaces to implementations of existing codec
+    technology developed elsewhere. Implementers may support any combination of
+    codecs or none at all.
 
 Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
@@ -65,6 +70,16 @@ spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
     type: attribute; text: powerEfficient; url: dom-mediacapabilitiesinfo-powerefficient
 </pre>
 
+<pre class='biblio'>
+{
+  "CODEC-REGISTRY": {
+      "href": "https://wicg.github.io/web-codecs/codec_registry.html",
+      "title": "WebCodecs Codec Registry",
+      "publisher": "WICG"
+  }
+}
+</pre>
+
 
 Definitions {#definitions}
 ==========================
@@ -90,18 +105,6 @@ Definitions {#definitions}
     objects. Such resources may be quickly exhuasted and should be released
     immediately when no longer in use.
 
-: <dfn lt="AVC">Advanced Video Coding (AVC)</dfn>
-:: Also known as H.264. Refers to the methods of video compression as defined by
-    [[!iso14496-10]].
-
-: <dfn lt="Picture Parameter Set (PPS)|PPS">Picture Parameter Set (PPS)</dfn>
-:: A set of parameters describing <a>AVC</a> coded pictures as defined by
-    [[!iso14496-10]].
-
-: <dfn lt="Sequence Parameter Set (SPS)|SPS">Sequence Parameter Set (SPS)</dfn>
-:: A set of parameters describing a sequence of <a>AVC</a> coded video as
-    defined by [[!iso14496-10]].
-
 Codec Processing Model {#codec-processing-model}
 ================================================
 
@@ -110,11 +113,11 @@ Background {#processing-model-background}
 
 This section is non-normative.
 
-The codec interfaces defined by the specification designed such that new codec
-tasks may be scheduled while previous tasks are still pending. For example, web
-authors may call `decode()` without waiting for a previous `decode()` to
-complete. This is achieved by offloading underlying codec tasks to a separate
-thread for parallel execution.
+The codec interfaces defined by the specification are designed such that new
+codec tasks may be scheduled while previous tasks are still pending. For
+example, web authors may call `decode()` without waiting for a previous
+`decode()` to complete. This is achieved by offloading underlying codec tasks to
+a separate thread for parallel execution.
 
 This section describes threading behaviors as they are visible from the
 perspective of web authors. Implementers may choose to use more or less threads
@@ -247,9 +250,10 @@ Methods {#audiodecoder-methods}
     [=Enqueues a control message=] to configure the audio decoder for decoding
     chunks as described by |config|.
 
-    NOTE: Authors should first check support by calling
-        {{AudioDecoder/isConfigSupported()}} with |config| to avoid error paths
-        in the steps below.
+    NOTE: This method will trigger a {{NotSupportedError}} if the user agent
+        does not support |config|. Authors should first check support by calling
+        {{AudioDecoder/isConfigSupported()}} with |config|. User agents are not
+        required to support any particular codec type or configuration.
 
     When invoked, run these steps:
     1. If |config| is not a [=valid AudioDecoderConfig=], throw a
@@ -475,9 +479,10 @@ Methods {#videodecoder-methods}
     [=Enqueues a control message=] to configure the video decoder for decoding
     chunks as described by |config|.
 
-    NOTE: Authors should first check support by calling
-        {{VideoDecoder/isConfigSupported()}} with |config| to avoid error paths
-        in the steps below.
+    NOTE: This method will trigger a {{NotSupportedError}} if the user agent
+        does not support |config|. Authors should first check support by calling
+        {{VideoDecoder/isConfigSupported()}} with |config|. User agents are not
+        required to support any particular codec type or configuration.
 
     When invoked, run these steps:
     1. If |config| is not a [=valid VideoDecoderConfig=], throw a
@@ -721,9 +726,10 @@ Methods {#audioencoder-methods}
     [=Enqueues a control message=] to configure the audio encoder for
     decoding chunks as described by |config|.
 
-    NOTE: Authors should first check support by calling
-        {{AudioEncoder/isConfigSupported()}} with |config| to avoid error paths
-        in the steps below.
+    NOTE: This method will trigger a {{NotSupportedError}} if the user agent
+        does not support |config|. Authors should first check support by calling
+        {{AudioEncoder/isConfigSupported()}} with |config|. User agents are not
+        required to support any particular codec type or configuration.
 
     When invoked, run these steps:
     1. If |config| is not a [=valid AudioEncoderConfig=], throw a
@@ -971,9 +977,10 @@ Methods {#videoencoder-methods}
     [=Enqueues a control message=] to configure the video encoder for
     decoding chunks as described by |config|.
 
-    NOTE: Authors should first check support by calling
-        {{VideoEncoder/isConfigSupported()}} with |config| to avoid error paths
-        in the steps below.
+    NOTE: This method will trigger a {{NotSupportedError}} if the user agent
+        does not support |config|. Authors should first check support by calling
+        {{VideoEncoder/isConfigSupported()}} with |config|. User agents are not
+        required to support any particular codec type or configuration.
 
     When invoked, run these steps:
     1. If |config| is not a [=valid VideoEncoderConfig=], throw a
@@ -1131,7 +1138,9 @@ Algorithms {#videoencoder-algorithms}
 
                 NOTE: This includes supplying the
                     {{VideoDecoderConfig/description}} to describe codec
-                    specific "extradata" like the avcC bytes for AVC.
+                    specific "extradata", the use of which may be further
+                    described in codec registrations listed in the
+                    [[CODEC-REGISTRY]].
         3. If |output_config| and {{VideoEncoder/[[active output config]]}} are
             <a>equal dictionaries</a>, set |output_config| to null. Otherwise,
             set {{VideoEncoder/[[active output config]]}} to |output_config|.
@@ -1317,63 +1326,24 @@ dictionary VideoEncoderSupport {
 
 <dfn export>Codec String</dfn>{#config-codec-string}
 ----------------------------------------------------
-In other media specifications, codec strings historically accompanied a
-    [=MIME type=] as the "codecs=" parameter
-    ({{MediaSource/isTypeSupported()}}, {{HTMLMediaElement/canPlayType()}})
-    [[RFC6381]]. In this specification, encoded media is not containerized; hence,
-    only the value of the codecs parameter is accepted.
+A codec string describes a given codec format to be used for encoding or
+decoding.
 
 A <dfn>valid codec string</dfn> must meet the following conditions.
 1. Is valid per the relevant codec specification (see examples below).
-
 2. It describes a single codec.
-
-NOTE: Not a comma separated list.
-
 3. It is unambiguous about codec profile and level for codecs that define these
     concepts.
 
+NOTE: In other media specifications, codec strings historically accompanied a
+    [=MIME type=] as the "codecs=" parameter
+    ({{MediaSource/isTypeSupported()}}, {{HTMLMediaElement/canPlayType()}})
+    [[RFC6381]]. In this specification, encoded media is not containerized;
+    hence, only the value of the codecs parameter is accepted.
 
-<div class='note'>
-  NOTE: There is no unified specification for codec strings. Each codec has its
-  own unique string format, specified by the authors of the codec. Relevant
-  specifications include:
-
-  * h264, aac - [[RFC6381]]
-  * vp9 -
-      <a href="https://www.webmproject.org/vp9/mp4/#codecs-parameter-string">
-        https://www.webmproject.org/vp9/mp4/#codecs-parameter-string
-      </a>
-  * hevc -
-      <a href="https://www.iso.org/standard/74429.html">
-        ISO IEC 14496-15 dated 2012 or newer in the Annex E.3
-      </a>
-  * av1 -
-      <a href="https://aomediacodec.github.io/av1-isobmff/#codecsparam">
-        https://aomediacodec.github.io/av1-isobmff/#codecsparam
-      </a>
-
-</div>
-
-<div class='example'>
-Valid examples include:<br>
-  * 'vp8'
-  * 'vp09.00.10.08'
-  * 'avc1.4D401E',
-  * 'opus',
-  * 'mp4a.40.2',
-  * 'flac'
-
-Invalid examples include:<br>
-  * 'video/webm; codecs="vp8"' (invalid to supply full mimetype; valid as just
-        'vp8')<br>
-  * 'codecs="opus"' (invalid to include codecs= prefix)<br>
-  * ‘flac,vorbis’ (describes more than one codec)<br>
-  * ‘vp9’ (ambiguous about profile and level)<br>
-  * 'video/mp4' (describes a container, not a codec)<br>
-
-</div>
-
+The format and semantics for codec strings are defined by codec registrations
+listed in the [[CODEC-REGISTRY]]. A compliant implementation may support any
+combination of codec registrations or none at all.
 
 AudioDecoderConfig{#audio-decoder-config}
 -----------------------------------------
@@ -1407,7 +1377,9 @@ To check if an {{AudioDecoderConfig}} is a <dfn>valid AudioDecoderConfig</dfn>,
   <dd>
     A sequence of codec specific bytes, commonly known as extradata.
 
-    NOTE: For example, the vorbis "code book".
+    NOTE: The registrations in the [[CODEC-REGISTRY]] describe whether/how to
+        populate this sequence, corresponding to the provided
+        {{AudioDecoderConfig/codec}}.
   </dd>
 </dl>
 
@@ -1456,7 +1428,9 @@ run these steps:
   <dd>
     A sequence of codec specific bytes, commonly known as extradata.
 
-    NOTE: Examples include the VP9 vpcC bytes or the AVC avcC bytes.
+    NOTE: The registrations in the [[CODEC-REGISTRY]] may describe whether/how
+        to populate this sequence, corresponding to the provided
+        {{VideoDecoderConfig/codec}}.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>codedWidth</dfn></dt>
@@ -1527,6 +1501,9 @@ dictionary AudioEncoderConfig {
 </xmp>
 </pre>
 
+NOTE: Codec-specific extensions to {{AudioEncoderConfig}} may be defined by the
+    registrations in the [[CODEC-REGISTRY]].
+
 To check if an {{AudioEncoderConfig}} is a <dfn>valid AudioEncoderConfig</dfn>,
 run these steps:
 1. If {{AudioEncoderConfig/codec}} is not a <a>valid codec string</a>, return
@@ -1557,11 +1534,12 @@ dictionary VideoEncoderConfig {
   unsigned long displayWidth;
   unsigned long displayHeight;
   HardwareAcceleration hardwareAcceleration = "allow";
-
-  AvcEncoderConfig avc;
 };
 </xmp>
 </pre>
+
+NOTE: Codec-specific extensions to {{VideoEncoderConfig}} may be defined by the
+    registrations in the [[CODEC-REGISTRY]].
 
 To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
     run these steps:
@@ -1571,8 +1549,6 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
     = 0, return `false`.
 3. If {{VideoEncoderConfig/displayWidth}} = 0 or
     {{VideoEncoderConfig/displayHeight}} = 0, return `false`.
-4. If {{VideoEncoderConfig/avc}} is present, but {{VideoEncoderConfig/codec}}
-    does not describe the <a>AVC</a> codec, per [[RFC6381]], return `false`.
 4. Return `true`.
 
 <dl>
@@ -1637,69 +1613,11 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
 </div>
 
 <dl>
-  <dt><dfn dict-member for=VideoEncoderConfig>avc</dfn></dt>
-  <dd>Contains codec specific configuration options for the AVC (H.264) codec.</dd>
-
   <dt><dfn dict-member for=VideoEncoderConfig>hardwareAcceleration</dfn></dt>
   <dd>
     Configures hardware acceleration for this codec. See
     {{HardwareAcceleration}}.
   </dd>
-</dl>
-
-### AvcEncoderConfig ### {#avc-encoder-config}
-<pre class='idl'>
-<xmp>
-dictionary AvcEncoderConfig {
-  AvcBitstreamFormat format = "avc";
-};
-</xmp>
-</pre>
-
-<dl>
-  <dt><dfn dict-member for=AvcEncoderConfig>format</dfn></dt>
-  <dd>
-    Configures the format of output <a>AVC</a> {{EncodedVideoChunk}}s. See
-    {{AvcBitstreamFormat}}.
-  </dd>
-</dl>
-
-#### AvcBitstreamFormat #### {#avc-bitstream-format}
-<pre class='idl'>
-<xmp>
-enum AvcBitstreamFormat {
-  "annexb",
-  "avc",
-};
-</xmp>
-</pre>
-The {{AvcBitstreamFormat}} determines the location of <a>Sequence Parameter
-Set (SPS)</a> and <a>Picture Parameter Set (PPS)</a> data, and mechanisms for
-packaging the bitstream.
-
-<dl>
-  <dt><dfn enum-value for=AvcBitstreamFormat>annexb</dfn></dt>
-  <dd>
-    This format is as described by [[!iso14496-10]], Annex B. Notably,
-    <a>SPS</a> and <a>PPS</a> data are included periodically throughout the
-    bitstream.
-
-    NOTE: This format is commonly used in live-streaming applications, where
-        including the SPS and PPS data periodically allows users to easily start
-        from the middle of the stream.
-  </dd>
-  <dt><dfn enum-value for=AvcBitstreamFormat>avc</dfn></dt>
-  <dd>
-    This format is as described by [[!iso14496-15]], Section 5. Notably,
-    <a>SPS</a> and <a>PPS</a> data are not included in the bitstream and are
-    instead passed out of band as a AVCDecoderConfigurationRecord as defined by
-    [[!iso14496-15]]. This structure is emitted via the
-    {{VideoEncoder/[[output callback]]}} as the
-    {{VideoDecoderConfig/description}} of the {{VideoDecoderConfig}}
-    |output_config|.
-
-    NOTE: This format is commonly used in .MP4 files, where the player generally
-        has random access to the media data.
 </dl>
 
 Hardware Acceleration{#hardware-acceleration}


### PR DESCRIPTION
This moves codec-specific defintions / descriptions into a registry.
I've also added some text to the main document to clarify that support
for any given codec is not required.

Fixes #143. Fixes #126.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/149.html" title="Last updated on Mar 17, 2021, 11:39 PM UTC (49baae7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/149/57e2560...49baae7.html" title="Last updated on Mar 17, 2021, 11:39 PM UTC (49baae7)">Diff</a>